### PR TITLE
Update the version of the dependencies

### DIFF
--- a/BetterQtCreatorDiscordRichPresence.json
+++ b/BetterQtCreatorDiscordRichPresence.json
@@ -8,7 +8,7 @@
     "Description" : "Integrate Qt Creator with Discord Rich Presence",
     "Url" : "https://github.com/TheMiksHacker/BetterQtcDRP",
     "Dependencies" : [
-        { "Name" : "Core", "Version" : "4.12.0" },
-        { "Name" : "ProjectExplorer", "Version" : "4.12.0" }
+        { "Name" : "Core", "Version" : "4.15.2" },
+        { "Name" : "ProjectExplorer", "Version" : "4.15.2" }
     ]
 }


### PR DESCRIPTION
The BetterQtcDRP plugin looks for the Core(4.14.1) and ProjectExplorer(4.14.1) dependencies.
As of Qt Creator 4.15.2, the Core dependency and the ProjectExplorer dependency are both on version 4.15.2, resulting in the following error:
```
Could not resolve dependency 'Core(4.14.1)'
Could not resolve dependency 'ProjectExplorer(4.14.1)'
```  
<br>
I changed the BetterQtCreatorDiscordRichPresence.json file so it looks for the right, updated dependencies.  

Closes maksalees/BetterQtcDRP/#2